### PR TITLE
Fix conversion if the old xp was exactly Integer.MAX_VALUE and use double for getXpNeededToLevelUp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>me.eccentric_nz.gamemodeinventories</groupId>
     <artifactId>GameModeInventories</artifactId>
-    <version>3.6.0</version>
+    <version>3.6.1</version>
     <name>GameModeInventories</name>
     <!-- use a profile here so that the Jenkins build can fetch the
     CoreProtect dependency locally - there is no repo available! -->

--- a/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesXPCalculator.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesXPCalculator.java
@@ -84,7 +84,7 @@ public class GameModeInventoriesXPCalculator {
      * @return Gets the players current experience points towards the next level.
      */
     public static float getFractionalExp(int level, double exp) {
-        return (float) (exp - getXpForLevel(level)/getXpNeededToLevelUp(level));
+        return (float) ((exp - getXpForLevel(level))/getXpNeededToLevelUp(level));
     }
 
     /**

--- a/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesXPCalculator.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesXPCalculator.java
@@ -84,7 +84,7 @@ public class GameModeInventoriesXPCalculator {
      * @return Gets the players current experience points towards the next level.
      */
     public static float getFractionalExp(int level, double exp) {
-        return (float)(exp - getXpForLevel(level))/getXpNeededToLevelUp(level);
+        return (float) (exp - getXpForLevel(level)/getXpNeededToLevelUp(level));
     }
 
     /**
@@ -113,7 +113,7 @@ public class GameModeInventoriesXPCalculator {
      * @return the amount of experience at this level in the level bar
      * @throws IllegalArgumentException if the level is less than 0
      */
-    public static int getXpNeededToLevelUp(int level) {
+    public static double getXpNeededToLevelUp(int level) {
         Preconditions.checkArgument(level >= 0, "Level may not be negative.");
         return level > 30
             ? 9 * level - 158

--- a/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
@@ -22,8 +22,8 @@ public class GameModeInventoriesXPConverter {
     // Old methods optimized a bit
     private static int oldGetLevelForExp(double oldExp) {
         return (oldExp < 255)
-                ? (int)(oldExp / 17)
-                : (oldExp < 887)
+            ? (int)(oldExp / 17)
+            : (oldExp < 887)
                 ? (int)((29.5 + Math.sqrt(29.5 * 29.5 - 4 * 1.5 * (360 - oldExp))) / (2 * 1.5))
                 : (int)((151.5 + Math.sqrt(151.5 * 151.5 - 4 * 3.5 * (2220 - oldExp))) / (2 * 3.5));
     }

--- a/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
@@ -4,7 +4,6 @@ import me.eccentric_nz.gamemodeinventories.GameModeInventories;
 import me.eccentric_nz.gamemodeinventories.GameModeInventoriesXPCalculator;
 import org.bukkit.util.FileUtil;
 import java.io.File;
-import java.util.Arrays;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -18,67 +17,39 @@ public class GameModeInventoriesXPConverter {
 
     public GameModeInventoriesXPConverter(GameModeInventories plugin) {
         this.plugin = plugin;
-        initLookupTables(1000000);
     }
 
-    // Old methods
-    private static int xpTotalToReachLevel[];
-
-    private static void initLookupTables(int maxLevel) {
-        xpTotalToReachLevel = new int[maxLevel];
-
-        for (int i = 0; i < xpTotalToReachLevel.length; i++) {
-            xpTotalToReachLevel[i] = i >= 30
-                    ? (int)(3.5 * i * i - 151.5 * i + 2220)
-                    : i >= 16
-                    ? (int)(1.5 * i * i - 29.5 * i + 360)
-                    : 17 * i;
-        }
-
+    // Old methods optimized a bit
+    private static int oldGetLevelForExp(double oldExp) {
+        return (oldExp < 255)
+                ? (int)(oldExp / 17)
+                : (oldExp < 887)
+                ? (int)((29.5 + Math.sqrt(29.5 * 29.5 - 4 * 1.5 * (360 - oldExp))) / (2 * 1.5))
+                : (int)((151.5 + Math.sqrt(151.5 * 151.5 - 4 * 3.5 * (2220 - oldExp))) / (2 * 3.5));
     }
 
-    private static int oldGetLevelForExp(int exp) {
-        if (exp <= 0) {
-            return 0;
-        }
-        if (exp > xpTotalToReachLevel[xpTotalToReachLevel.length - 1]) {
-            // need to extend the lookup tables
-            int newMax = oldCalculateLevelForExp(exp) * 2;
-            initLookupTables(newMax);
-        }
-        int pos = Arrays.binarySearch(xpTotalToReachLevel, exp);
-        return pos < 0 ? -pos - 2 : pos;
+    private static double oldGetXpNeededToLevelUp(int oldLevel) {
+        return oldLevel > 30
+            ? 62.0 + (oldLevel - 30.0) * 7.0
+            : oldLevel >= 16
+                ? 17.0 + (oldLevel - 15.0) * 3.0
+                : 17.0;
     }
 
-    private static int oldCalculateLevelForExp(int exp) {
-        int level = 0;
-        int curExp = 7; // level 1
-        int incr = 10;
+    private static double oldGetXpForLevel(int oldLevel) {
+        return oldLevel >= 30
+            ? 3.5 * oldLevel * oldLevel - 151.5 * oldLevel + 2220
+            : oldLevel >= 16
+                ? 1.5 * oldLevel * oldLevel - 29.5 * oldLevel + 360
+                : 17.0 * oldLevel;
 
-        while (curExp <= exp) {
-            curExp += incr;
-            level++;
-            incr += (level % 2 == 0) ? 3 : 4;
-        }
-        return level;
-    }
-
-    private static int oldGetXpNeededToLevelUp(int level) {
-        return level > 30 ? 62 + (level - 30) * 7 : level >= 16 ? 17 + (level - 15) * 3 : 17;
-    }
-
-    private static int oldGetXpForLevel(int level) {
-        if (level >= xpTotalToReachLevel.length) {
-            initLookupTables(level * 2);
-        }
-        return xpTotalToReachLevel[level];
     }
 
     // Conversion
     private double convertXp(double oldXp) {
         if(oldXp < 0) return 0;
-        int oldLevel = oldGetLevelForExp((int)oldXp);
-        double oldPct = (oldXp - oldGetXpForLevel(oldLevel)) / (double) (oldGetXpNeededToLevelUp(oldLevel));
+        int oldLevel = oldGetLevelForExp(oldXp);
+        double oldPct = (oldXp - oldGetXpForLevel(oldLevel)) / oldGetXpNeededToLevelUp(oldLevel);
         return GameModeInventoriesXPCalculator.getXpForLevel(oldLevel) + Math.round(GameModeInventoriesXPCalculator.getXpNeededToLevelUp(oldLevel) * oldPct);
     }
 

--- a/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/database/GameModeInventoriesXPConverter.java
@@ -42,7 +42,6 @@ public class GameModeInventoriesXPConverter {
             : oldLevel >= 16
                 ? 1.5 * oldLevel * oldLevel - 29.5 * oldLevel + 360
                 : 17.0 * oldLevel;
-
     }
 
     // Conversion

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: me.eccentric_nz.gamemodeinventories.GameModeInventories
 name: GameModeInventories
 load: POSTWORLD
 softdepend: [ Multiverse-Core,MultiWorld,CoreProtect,LogBlock ]
-version: 3.6.0
+version: 3.6.1
 api-version: '1.20.5'
 libraries:
   - com.zaxxer:HikariCP:5.0.1


### PR DESCRIPTION
I noticed that with the old method the conversion for Integer.MAX_VALUE didn't return the exact value, I deleted the lookup table since it was easier and faster with direct formulae.