### PR TITLE
(Paper 26.2-Support) Migrated from SnakeYaml to Java Base64

### DIFF
--- a/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesBukkitSerialization.java
+++ b/src/main/java/me/eccentric_nz/gamemodeinventories/GameModeInventoriesBukkitSerialization.java
@@ -22,12 +22,12 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.io.BukkitObjectInputStream;
 import org.bukkit.util.io.BukkitObjectOutputStream;
-import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.logging.Level;
+import java.util.Base64;
 
 /**
  * @author eccentric_nz
@@ -59,7 +59,7 @@ public class GameModeInventoriesBukkitSerialization {
                 }
                 // Serialize that array
             }
-            return Base64Coder.encodeLines(outputStream.toByteArray());
+            return Base64.getEncoder().encodeToString(outputStream.toByteArray());
         } catch (IOException e) {
             throw new IllegalStateException("Unable to save item stacks.", e);
         }
@@ -67,7 +67,7 @@ public class GameModeInventoriesBukkitSerialization {
 
     public static ItemStack[] fromDatabase(String data) throws IOException {
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64Coder.decodeLines(data));
+            ByteArrayInputStream inputStream = new ByteArrayInputStream(Base64.getMimeDecoder().decode(data));
             ItemStack[] inventory;
             try (BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
                 int size = dataInput.readInt();


### PR DESCRIPTION
Hey there!

Paper 26.2 dropped the SnakeYaml base64 coder which leads to quite a nasty bug: the plugin loads correctly, but when actually requiring to save/load data, it crashes, resulting in data-loss 

This simple fix uses Java's mime-decoder to also properly handle the linefeeds you went with in the past. 